### PR TITLE
Add initializing constructor to LabelMultisetType

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,13 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<developers>
 		<developer>

--- a/src/main/java/net/imglib2/type/label/LabelMultisetEntryList.java
+++ b/src/main/java/net/imglib2/type/label/LabelMultisetEntryList.java
@@ -8,20 +8,14 @@ import net.imglib2.type.label.LabelMultisetType.Entry;
 public class LabelMultisetEntryList
 		extends MappedObjectArrayList< LabelMultisetEntry, LongMappedAccess >
 {
-	/**
-	 * creates underlying data array
-	 */
+	public LabelMultisetEntryList()
+	{
+		super( LabelMultisetEntry.type );
+	}
+
 	public LabelMultisetEntryList( final int capacity )
 	{
 		super( LabelMultisetEntry.type, capacity );
-	}
-
-	/**
-	 * doesn't create underlying data array
-	 */
-	protected LabelMultisetEntryList()
-	{
-		super( LabelMultisetEntry.type );
 	}
 
 	public LabelMultisetEntryList( final LongMappedAccessData data, final long baseOffset )

--- a/src/main/java/net/imglib2/type/label/LabelMultisetType.java
+++ b/src/main/java/net/imglib2/type/label/LabelMultisetType.java
@@ -50,6 +50,24 @@ public class LabelMultisetType extends AbstractNativeType< LabelMultisetType > i
 		this( null, new VolatileLabelMultisetArray( 1, true, new long[] { Label.INVALID } ) );
 	}
 
+	// this is the constructor if you want it to be a variable
+	public LabelMultisetType( final LabelMultisetEntry entry )
+	{
+		this();
+		access.getValue( i, this.entries );
+		this.entries.add( entry );
+		this.access.setArgMax( i, entry.getId() );
+	}
+
+	// this is the constructor if you want it to be a variable
+	public LabelMultisetType( final LabelMultisetEntryList entries )
+	{
+		this();
+		access.getValue( i, this.entries );
+		this.entries.addAll( entries );
+		updateArgMax();
+	}
+
 	private LabelMultisetType( final NativeImg< ?, VolatileLabelMultisetArray > img, final VolatileLabelMultisetArray access )
 	{
 		this.entries = new LabelMultisetEntryList();

--- a/src/main/java/net/imglib2/type/label/MappedObjectArrayList.java
+++ b/src/main/java/net/imglib2/type/label/MappedObjectArrayList.java
@@ -11,6 +11,8 @@ public class MappedObjectArrayList< O extends MappedObject< O, T >, T extends Ma
 		extends AbstractList< O >
 		implements RefList< O >
 {
+	private static final int DEFAULT_CAPACITY = 1;
+
 	private final O type;
 
 	private MappedAccessData< T > data;
@@ -23,27 +25,23 @@ public class MappedObjectArrayList< O extends MappedObject< O, T >, T extends Ma
 
 	private final ConcurrentLinkedQueue< O > tmpObjRefs = new ConcurrentLinkedQueue<>();
 
-	// TODO: fix confusing constructor overloads
+	public MappedObjectArrayList( final O type )
+	{
+		this( type, DEFAULT_CAPACITY );
+	}
 
-	// creates underlying data array
 	public MappedObjectArrayList( final O type, final int capacity )
 	{
 		this( type, type.storageFactory.createStorage( ByteUtils.INT_SIZE + capacity * type.getSizeInBytes() ), 0 );
 	}
 
-	// doesn't create underlying data array
 	protected MappedObjectArrayList( final O type, final MappedAccessData< T > data, final long baseOffset )
-	{
-		this( type );
-		referToDataAt( data, baseOffset );
-		ensureCapacity( 0 );
-	}
-
-	// doesn't create underlying data array
-	protected MappedObjectArrayList( final O type )
 	{
 		this.type = type;
 		this.access = type.storageFactory.createAccess();
+
+		referToDataAt( data, baseOffset );
+		ensureCapacity( 0 );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/type/label/VolatileLabelMultisetArray.java
+++ b/src/main/java/net/imglib2/type/label/VolatileLabelMultisetArray.java
@@ -11,7 +11,7 @@ public class VolatileLabelMultisetArray implements VolatileAccess, VolatileArray
 
 	private final long[] argMax;
 
-	private final MappedAccessData< LongMappedAccess > listData;
+	private final LongMappedAccessData listData;
 
 	private final long listDataUsedSizeInBytes;
 
@@ -21,13 +21,13 @@ public class VolatileLabelMultisetArray implements VolatileAccess, VolatileArray
 		this.argMax = argMax;
 		listData = LongMappedAccessData.factory.createStorage( 16 );
 		listDataUsedSizeInBytes = 0;
-		new MappedObjectArrayList<>( LabelMultisetEntry.type, listData, 0 ).add( new LabelMultisetEntry() );
+		new MappedObjectArrayList<>( LabelMultisetEntry.type, listData, 0 );
 		this.isValid = isValid;
 	}
 
 	public VolatileLabelMultisetArray(
 			final int[] data,
-			final MappedAccessData< LongMappedAccess > listData,
+			final LongMappedAccessData listData,
 			final boolean isValid,
 			final long[] argMax )
 	{
@@ -36,7 +36,7 @@ public class VolatileLabelMultisetArray implements VolatileAccess, VolatileArray
 
 	public VolatileLabelMultisetArray(
 			final int[] data,
-			final MappedAccessData< LongMappedAccess > listData,
+			final LongMappedAccessData listData,
 			final long listDataUsedSizeInBytes,
 			final boolean isValid,
 			final long[] argMax )
@@ -71,7 +71,7 @@ public class VolatileLabelMultisetArray implements VolatileAccess, VolatileArray
 		return data;
 	}
 
-	public MappedAccessData< LongMappedAccess > getListData()
+	public LongMappedAccessData getListData()
 	{
 		return listData;
 	}

--- a/src/main/java/net/imglib2/type/label/VolatileLabelMultisetType.java
+++ b/src/main/java/net/imglib2/type/label/VolatileLabelMultisetType.java
@@ -30,6 +30,18 @@ public class VolatileLabelMultisetType
 		super( new LabelMultisetType(), true );
 	}
 
+	// this is the constructor if you want it to be a variable
+	public VolatileLabelMultisetType( final LabelMultisetEntry entry )
+	{
+		super( new LabelMultisetType( entry ), true );
+	}
+
+	// this is the constructor if you want it to be a variable
+	public VolatileLabelMultisetType( final LabelMultisetEntryList entries )
+	{
+		super( new LabelMultisetType( entries ), true );
+	}
+
 	protected VolatileLabelMultisetType( final LabelMultisetType t )
 	{
 		super( t, true );

--- a/src/test/java/net/imglib2/type/label/LabelMultisetTypeTest.java
+++ b/src/test/java/net/imglib2/type/label/LabelMultisetTypeTest.java
@@ -1,0 +1,51 @@
+package net.imglib2.type.label;
+
+import java.util.Iterator;
+import java.util.Random;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.imglib2.type.label.LabelMultisetType.Entry;
+
+public class LabelMultisetTypeTest
+{
+	private static final Random rnd = new Random();
+
+	@Test
+	public void testInitializationEmpty()
+	{
+		final LabelMultisetType lmtEmpty = new LabelMultisetType();
+		Assert.assertEquals( Label.INVALID, lmtEmpty.argMax() );
+		Assert.assertTrue( lmtEmpty.isEmpty() );
+	}
+
+	@Test
+	public void testInitializationSingleEntry()
+	{
+		final LabelMultisetType lmtSingleEntry = new LabelMultisetType( new LabelMultisetEntry( 5, 2 ) );
+		Assert.assertEquals( 5, lmtSingleEntry.argMax() );
+		Assert.assertEquals( 2, lmtSingleEntry.size() );
+		Assert.assertEquals( 1, lmtSingleEntry.entrySet().size() );
+	}
+
+	@Test
+	public void testInitializationMultipleEntries()
+	{
+		final LabelMultisetEntryList multipleEntries = new LabelMultisetEntryList();
+		final int numEntries = rnd.nextInt( 20 );
+		for ( int i = 0; i < numEntries; ++i )
+			multipleEntries.add( new LabelMultisetEntry( rnd.nextInt( 1000 ), rnd.nextInt( 10 ) ) );
+		final LabelMultisetType lmtMultipleEntries = new LabelMultisetType( multipleEntries );
+		Assert.assertEquals( numEntries, lmtMultipleEntries.entrySet().size() );
+		final Iterator< ? extends Entry< Label > > itExpected = multipleEntries.iterator();
+		final Iterator< Entry< Label > > itActual = lmtMultipleEntries.entrySet().iterator();
+		while ( itExpected.hasNext() || itActual.hasNext() )
+		{
+			final Entry< Label > entryExpected = itExpected.next();
+			final Entry< Label > entryActual = itActual.next();
+			Assert.assertEquals( entryExpected.getElement().id(), entryActual.getElement().id() );
+			Assert.assertEquals( entryExpected.getCount(), entryActual.getCount() );
+		}
+	}
+}


### PR DESCRIPTION
Currently there is no easy way to create an instance of `LabelMultisetType` with a pre-defined set of entries. This PR adds this functionality, which can be useful in the following situations:
* creating a test image using high-level API: [igorpisarev/n5-imglib2/N5LabelMultisetsTest.java](https://github.com/igorpisarev/n5-imglib2/blob/test-label-multisets/src/test/java/org/janelia/saalfeldlab/n5/imglib2/N5LabelMultisetsTest.java#L86-L96)
* creating a default `LabelMultisetType` variable to use by generic code such as [N5Utils.java#L488](https://github.com/saalfeldlab/n5-imglib2/blob/master/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5Utils.java#L488)

As a part of this PR, I also changed how the underlying storage is created for `LabelMultisetEntryList`. Now it follows a simpler logic and can either take a storage array or allocate it. This also makes it behave more like standard Java collections and prevents accidental misuse.

cc @axtimwalde @hanslovsky
