### PR TITLE
Optimize serialization

### DIFF
--- a/src/main/java/net/imglib2/type/label/FromIntegerTypeConverter.java
+++ b/src/main/java/net/imglib2/type/label/FromIntegerTypeConverter.java
@@ -41,7 +41,7 @@ public class FromIntegerTypeConverter< I extends IntegerType< I > > implements C
 		if ( ByteUtils.getLong( data, Integer.BYTES ) != newVal )
 		{
 			ByteUtils.putLong( newVal, data, Integer.BYTES );
-			output.updateArgMax();
+			output.getAccess().setArgMax( output.getIndex(), newVal );
 		}
 	}
 

--- a/src/main/java/net/imglib2/type/label/LabelUtils.java
+++ b/src/main/java/net/imglib2/type/label/LabelUtils.java
@@ -32,7 +32,7 @@ public class LabelUtils
 		final LabelMultisetEntryList list = new LabelMultisetEntryList( listData, 0 );
 		final LabelMultisetEntryList list2 = new LabelMultisetEntryList();
 		final TIntObjectHashMap<TIntArrayList> listHashesAndOffsets = new TIntObjectHashMap<>();
-		final LabelMultisetEntry tentry = new LabelMultisetEntry( 0, 1 );
+		final LabelMultisetEntry tentry = new LabelMultisetEntry( 0, 1 ), ref = list.createRef();
 		int nextListOffset = 0;
 		int o = 0;
 		for ( final LabelMultisetType lmt : lmts )
@@ -44,7 +44,7 @@ public class LabelUtils
 				final long id = entry.getElement().id();
 				tentry.setId( id );
 				tentry.setCount( entry.getCount() );
-				list.add( tentry );
+				list.add( tentry, ref );
 			}
 			argMax.add( lmt.argMax() );
 
@@ -79,6 +79,7 @@ public class LabelUtils
 				nextListOffset += list.getSizeInBytes();
 			}
 		}
+		list.releaseRef( ref );
 
 		final byte[] bytes = new byte[ VolatileLabelMultisetArray.getRequiredNumberOfBytes( argMax.size(), data, nextListOffset ) ];
 

--- a/src/main/java/net/imglib2/type/label/MappedObjectArrayList.java
+++ b/src/main/java/net/imglib2/type/label/MappedObjectArrayList.java
@@ -87,8 +87,13 @@ public class MappedObjectArrayList< O extends MappedObject< O, T >, T extends Ma
 	private O createRefAt( final int index )
 	{
 		final O ref = createRef();
-		data.updateAccess( ref.access, elementBaseOffset + index * elementSizeInBytes() );
+		setRefAt( ref, index );
 		return ref;
+	}
+
+	private void setRefAt( final O ref, final int index )
+	{
+		data.updateAccess( ref.access, elementBaseOffset + index * elementSizeInBytes() );
 	}
 
 	@Override
@@ -138,7 +143,7 @@ public class MappedObjectArrayList< O extends MappedObject< O, T >, T extends Ma
 	{
 		if ( index < 0 || index >= size() )
 			throw new IndexOutOfBoundsException();
-		data.updateAccess( ref.access, elementBaseOffset + index * elementSizeInBytes() );
+		setRefAt( ref, index );
 		return ref;
 	}
 
@@ -147,22 +152,39 @@ public class MappedObjectArrayList< O extends MappedObject< O, T >, T extends Ma
 	{
 		if ( index < 0 || index >= size() )
 			throw new IndexOutOfBoundsException();
-		final O ref = createRefAt( index );
-		ref.set( element );
+		final O ref = createRef();
+		set( index, element, ref );
 		releaseRef( ref );
+		return null;
+	}
+
+	public O set( final int index, final O element, final O ref )
+	{
+		if ( index < 0 || index >= size() )
+			throw new IndexOutOfBoundsException();
+		setRefAt( ref, index );
+		ref.set( element );
 		return null;
 	}
 
 	@Override
 	public boolean add( final O obj )
 	{
+		final O ref = createRef();
+		final boolean ret = add( obj, ref );
+		releaseRef( ref );
+
+		return ret;
+	}
+
+	public boolean add( final O obj, final O ref )
+	{
 		final int size = size();
 		ensureCapacity( size + 1 );
 		setSize( size + 1 );
 
-		final O ref = createRefAt( size );
+		setRefAt( ref, size );
 		ref.set( obj );
-		releaseRef( ref );
 
 		return true;
 	}


### PR DESCRIPTION
Several optimizations that together give ~10-15% speedup when converting N5 to `LabelMultisetType`:
* directly set argmax when converting integer types
* add option to re-use the same reference to contents of `MappedObjectArrayList` instead of fetching it from the pool and putting it back every time
* store hashes of populated label multisets in a hashmap instead of a list to minimize looping