### PR TITLE
Fix arg max

### DIFF
--- a/src/main/java/net/imglib2/type/label/LabelMultisetType.java
+++ b/src/main/java/net/imglib2/type/label/LabelMultisetType.java
@@ -4,6 +4,7 @@ import java.math.BigInteger;
 import java.util.AbstractSet;
 import java.util.Collection;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import net.imglib2.img.NativeImg;
 import net.imglib2.type.AbstractNativeType;
@@ -115,6 +116,18 @@ public class LabelMultisetType extends AbstractNativeType< LabelMultisetType > i
 			public int size()
 			{
 				return entries.size();
+			}
+
+			@Override
+			public Stream< Entry< Label > > stream()
+			{
+				throw new UnsupportedOperationException( "Streams are not compatible with " + getClass().getName() + " because its iterator reuses the same reference." );
+			}
+
+			@Override
+			public Stream< Entry< Label> > parallelStream()
+			{
+				throw new UnsupportedOperationException( "Streams are not compatible with " + getClass().getName() + " because its iterator reuses the same reference." );
 			}
 		};
 	}

--- a/src/main/java/net/imglib2/type/label/LabelMultisetType.java
+++ b/src/main/java/net/imglib2/type/label/LabelMultisetType.java
@@ -498,13 +498,6 @@ public class LabelMultisetType extends AbstractNativeType< LabelMultisetType > i
 
 	public void updateArgMax()
 	{
-		this.access.setArgMax(
-				i,
-				this
-						.entrySet()
-						.stream()
-						.max( ( e1, e2 ) -> Integer.compare( e1.getCount(), e2.getCount() ) )
-						.map( e -> e.getElement().id() )
-						.orElse( Label.INVALID ) );
+		this.access.setArgMax( i, LabelUtils.getArgMax( entrySet() ) );
 	}
 }

--- a/src/main/java/net/imglib2/type/label/LabelMultisetTypeDownscaler.java
+++ b/src/main/java/net/imglib2/type/label/LabelMultisetTypeDownscaler.java
@@ -122,7 +122,7 @@ public class LabelMultisetTypeDownscaler
 				list.limitSize( maxNumEntriesPerPixel );
 				list.sortById();
 			}
-			argMax.add( list.stream().max( ( e1, e2 ) -> Integer.compare( e1.getCount(), e2.getCount() ) ).map( LabelMultisetEntry::getId ).orElse( Label.INVALID ) );
+			argMax.add( LabelUtils.getArgMax( list ) );
 
 			boolean makeNewList = true;
 			final int hash = list.hashCode();
@@ -177,7 +177,7 @@ public class LabelMultisetTypeDownscaler
 	{
 
 		final int[] curStorage = array.getCurrentStorageArray();
-		final long[] data = ( ( LongMappedAccessData ) array.getListData() ).data;
+		final long[] data = array.getListData().data;
 
 		final ByteBuffer bb = ByteBuffer.wrap( bytes );
 

--- a/src/main/java/net/imglib2/type/label/LabelUtils.java
+++ b/src/main/java/net/imglib2/type/label/LabelUtils.java
@@ -2,6 +2,7 @@ package net.imglib2.type.label;
 
 import java.lang.invoke.MethodHandles;
 import java.nio.ByteBuffer;
+import java.util.Collection;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -141,5 +142,20 @@ public class LabelUtils
 			ByteUtils.putByte( bb.get(), listData.data, i );
 		}
 		return new VolatileLabelMultisetArray( data, listData, true, argMax );
+	}
+
+	public static long getArgMax( final Collection< ? extends Entry< Label > > labelMultisetEntries )
+	{
+		int maxCount = 0;
+		long maxCountId = Label.INVALID;
+		for ( final Entry< Label > entry : labelMultisetEntries )
+		{
+			if ( maxCount < entry.getCount() )
+			{
+				maxCount = entry.getCount();
+				maxCountId = entry.getElement().id();
+			}
+		}
+		return maxCountId;
 	}
 }

--- a/src/main/java/net/imglib2/type/label/MappedObjectArrayList.java
+++ b/src/main/java/net/imglib2/type/label/MappedObjectArrayList.java
@@ -5,6 +5,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Stream;
 
 // TOOD: make unmodifiable version
 public class MappedObjectArrayList< O extends MappedObject< O, T >, T extends MappedAccess< T > >
@@ -356,5 +357,17 @@ public class MappedObjectArrayList< O extends MappedObject< O, T >, T extends Ma
 			quicksort( low, j, comparator, tmpRef1, tmpRef2, tmpRef3 );
 		if ( i < high )
 			quicksort( i, high, comparator, tmpRef1, tmpRef2, tmpRef3 );
+	}
+
+	@Override
+	public Stream< O > stream()
+	{
+		throw new UnsupportedOperationException( "Streams are not compatible with " + getClass().getName() + " because its iterator reuses the same reference." );
+	}
+
+	@Override
+	public Stream< O > parallelStream()
+	{
+		throw new UnsupportedOperationException( "Streams are not compatible with " + getClass().getName() + " because its iterator reuses the same reference." );
 	}
 }

--- a/src/test/java/net/imglib2/type/label/LabelMultisetTypeTest.java
+++ b/src/test/java/net/imglib2/type/label/LabelMultisetTypeTest.java
@@ -48,4 +48,17 @@ public class LabelMultisetTypeTest
 			Assert.assertEquals( entryExpected.getCount(), entryActual.getCount() );
 		}
 	}
+
+	@Test
+	public void testArgMax()
+	{
+		final LabelMultisetEntryList entries = new LabelMultisetEntryList();
+		entries.add( new LabelMultisetEntry( 2, 13 ) );
+		entries.add( new LabelMultisetEntry( 3, 15 ) );
+		entries.add( new LabelMultisetEntry( 4, 11 ) );
+		entries.add( new LabelMultisetEntry( 1, 14 ) );
+		Assert.assertEquals( 3, LabelUtils.getArgMax( entries ) );
+		final LabelMultisetType lmt = new LabelMultisetType( entries );
+		Assert.assertEquals( 3, lmt.argMax() );
+	}
 }


### PR DESCRIPTION
The custom iterator defined in `LabelMultisetEntryList` re-uses the same reference, so code like `entries.stream().max((e1, e2) -> ...` gives incorrect results because `e1` and `e2` are always equal.
The methods `stream()` and `parallelStream()` would now throw `UnsupportedOperationException`.