### PR TITLE
Allow Label and long parameters in label multiset methods

### DIFF
--- a/src/main/java/net/imglib2/type/label/LabelMultiset.java
+++ b/src/main/java/net/imglib2/type/label/LabelMultiset.java
@@ -104,11 +104,9 @@ public class LabelMultiset implements Multiset< Label >
 	}
 
 	@Override
-	public int count( final Object o )
+	public int count( final Label l )
 	{
-		if ( !( o instanceof Label ) ) { return 0; }
-
-		final int pos = entries.binarySearch( ( ( Label ) o ).id() );
+		final int pos = entries.binarySearch( l.id() );
 		if ( pos < 0 ) { return 0; }
 
 		return entries.get( pos ).getCount();

--- a/src/main/java/net/imglib2/type/label/LabelMultisetType.java
+++ b/src/main/java/net/imglib2/type/label/LabelMultisetType.java
@@ -190,10 +190,9 @@ public class LabelMultisetType extends AbstractNativeType< LabelMultisetType > i
 		return entries.isEmpty();
 	}
 
-	public boolean contains( final Object o )
+	public boolean contains( final Label l )
 	{
-		access.getValue( i, entries );
-		return o instanceof Label && entries.binarySearch( ( ( Label ) o ).id() ) >= 0;
+		return contains( l.id() );
 	}
 
 	public boolean contains( final long id )
@@ -212,22 +211,25 @@ public class LabelMultisetType extends AbstractNativeType< LabelMultisetType > i
 		return true;
 	}
 
-	public boolean containsAll( final Collection< ? > c )
+	public boolean containsAll( final Collection< ? extends Label > c )
 	{
 		access.getValue( i, entries );
-		for ( final Object o : c )
+		for ( final Label l : c )
 		{
-			if ( !( o instanceof Label && entries.binarySearch( ( ( Label ) o ).id() ) >= 0 ) ) { return false; }
+			if ( entries.binarySearch( l.id() ) < 0 ) { return false; }
 		}
 		return true;
 	}
 
-	public int count( final Object o )
+	public int count( final Label l )
+	{
+		return count( l.id() );
+	}
+
+	public int count( final long id )
 	{
 		access.getValue( i, entries );
-		if ( !( o instanceof Label ) ) { return 0; }
-
-		final int pos = entries.binarySearch( ( ( Label ) o ).id() );
+		final int pos = entries.binarySearch( id );
 		if ( pos < 0 ) { return 0; }
 
 		return entries.get( pos ).getCount();

--- a/src/main/java/net/imglib2/type/label/Multiset.java
+++ b/src/main/java/net/imglib2/type/label/Multiset.java
@@ -8,7 +8,7 @@ import java.util.Set;
  */
 public interface Multiset< E > extends Collection< E >
 {
-	public int count( Object element );
+	public int count( E element );
 
 //	public Set< E > elementSet();
 


### PR DESCRIPTION
Some methods like `count()` and `contains()` currently require an `Object` parameter and do an internal check if the given object is an instance of type `Label`. This PR provides two streamlined versions of each method instead that take either `Label` or `long` parameter.

This allows to efficiently use these methods for primitive type ids, and also to avoid confusing results because of autoboxing: previously, if you call `count(id)` where `id` is a primitive long, it would automatically convert it into a `Long` object, and then the count method would return `0` because it's not an instance of `Label` (this was quite evil).