### PR TITLE
Add option to pass size numOccurrences parameter to FromIntegerTypeConverter.getAppropriate(Volatile)Type

### DIFF
--- a/src/main/java/net/imglib2/type/label/FromIntegerTypeConverter.java
+++ b/src/main/java/net/imglib2/type/label/FromIntegerTypeConverter.java
@@ -13,24 +13,16 @@ public class FromIntegerTypeConverter< I extends IntegerType< I > > implements C
 		return listData;
 	}
 
+	@Deprecated
 	public static LabelMultisetType getAppropriateType()
 	{
-		return getAppropriateType( 1 );
+		return LabelMultisetType.singleEntryWithSingleOccurrence();
 	}
 
-	public static LabelMultisetType getAppropriateType( final int numOccurrences )
-	{
-		return new LabelMultisetType( new LabelMultisetEntry( Label.INVALID, numOccurrences ) );
-	}
-
+	@Deprecated
 	public static VolatileLabelMultisetType getAppropriateVolatileType()
 	{
-		return getAppropriateVolatileType( 1 );
-	}
-
-	public static VolatileLabelMultisetType getAppropriateVolatileType( final int numOccurrences )
-	{
-		return new VolatileLabelMultisetType( new LabelMultisetEntry( Label.INVALID, numOccurrences ) );
+		return VolatileLabelMultisetType.singleEntryWithSingleOccurrence();
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/label/FromIntegerTypeConverter.java
+++ b/src/main/java/net/imglib2/type/label/FromIntegerTypeConverter.java
@@ -15,12 +15,22 @@ public class FromIntegerTypeConverter< I extends IntegerType< I > > implements C
 
 	public static LabelMultisetType getAppropriateType()
 	{
-		return new LabelMultisetType( new LabelMultisetEntry( Label.INVALID, 1 ) );
+		return getAppropriateType( 1 );
+	}
+
+	public static LabelMultisetType getAppropriateType( final int numOccurrences )
+	{
+		return new LabelMultisetType( new LabelMultisetEntry( Label.INVALID, numOccurrences ) );
 	}
 
 	public static VolatileLabelMultisetType getAppropriateVolatileType()
 	{
-		return new VolatileLabelMultisetType( new LabelMultisetEntry( Label.INVALID, 1 ) );
+		return getAppropriateVolatileType( 1 );
+	}
+
+	public static VolatileLabelMultisetType getAppropriateVolatileType( final int numOccurrences )
+	{
+		return new VolatileLabelMultisetType( new LabelMultisetEntry( Label.INVALID, numOccurrences ) );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/label/LabelMultisetType.java
+++ b/src/main/java/net/imglib2/type/label/LabelMultisetType.java
@@ -502,4 +502,14 @@ public class LabelMultisetType extends AbstractNativeType< LabelMultisetType > i
 	{
 		this.access.setArgMax( i, LabelUtils.getArgMax( entrySet() ) );
 	}
+
+	public static LabelMultisetType singleEntryWithSingleOccurrence()
+	{
+		return singleEntryWithNumOccurrences( 1 );
+	}
+
+	public static LabelMultisetType singleEntryWithNumOccurrences( final int numOccurrences )
+	{
+		return new LabelMultisetType( new LabelMultisetEntry( Label.INVALID, numOccurrences ) );
+	}
 }

--- a/src/main/java/net/imglib2/type/label/VolatileLabelMultisetType.java
+++ b/src/main/java/net/imglib2/type/label/VolatileLabelMultisetType.java
@@ -131,4 +131,14 @@ public class VolatileLabelMultisetType
 	{
 		return isValid() && other.isValid() && t.valueEquals( other.t );
 	}
+
+	public static VolatileLabelMultisetType singleEntryWithSingleOccurrence()
+	{
+		return singleEntryWithNumOccurrences( 1 );
+	}
+
+	public static VolatileLabelMultisetType singleEntryWithNumOccurrences( final int numOccurrences )
+	{
+		return new VolatileLabelMultisetType( new LabelMultisetEntry( Label.INVALID, numOccurrences ) );
+	}
 }


### PR DESCRIPTION
This is useful for creating multi-set types with different counts, e.g. for downsampled constant pixels.