### PR TITLE
Add new function to provide a reference when calling `count`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<groupId>net.imglib2</groupId>
 	<artifactId>imglib2-label-multisets</artifactId>
-	<version>0.11.1-SNAPSHOT</version>
+	<version>0.11.22-SNAPSHOT</version>
 
 	<name>ImgLib2 Label Multisets</name>
 	<description>Implementation of label multisets as an ImgLib2 native type.</description>

--- a/src/main/java/net/imglib2/type/label/LabelMultisetType.java
+++ b/src/main/java/net/imglib2/type/label/LabelMultisetType.java
@@ -239,6 +239,17 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 	return entries.get(pos).getCount();
   }
 
+  public int countWithRef(final long id, LabelMultisetEntry ref) {
+
+	access.getValue(i.get(), entries);
+	final int pos = entries.binarySearch(id, ref);
+	if (pos < 0) {
+	  return 0;
+	}
+
+	return entries.get(pos).getCount();
+  }
+
   public Set<Entry<Label>> entrySet() {
 
 	access.getValue(i.get(), entries);


### PR DESCRIPTION
When calling `count`, a significant portion of the time was spend grabbing a reference from the queue, and placing it back on. This provides a variant of `count`, `countWithRef` which allows you to pass in a reference which will be reused, without the overhead of the queue.