### PR TITLE
Fix Serialization Regression

### DIFF
--- a/.github/workflows/platform-test.yml
+++ b/.github/workflows/platform-test.yml
@@ -1,0 +1,30 @@
+name: test
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "*-[0-9]+.*"
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-14]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Java
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'zulu'
+          cache: 'maven'
+      - name: Maven Test
+        run: mvn -B clean test --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,10 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+		</dependency>
 
 		<!-- Test dependencies -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>36.0.0</version>
+		<version>37.0.0</version>
 	</parent>
 
 	<groupId>net.imglib2</groupId>
@@ -28,6 +28,19 @@
 	</licenses>
 
 	<developers>
+		<developer>
+			<id>cmhulbert</id>
+			<name>Caleb Hulbert</name>
+			<email>hulbertc@janelia.hhmi.org</email>
+			<url />
+			<organization>HHMI Janelia</organization>
+			<organizationUrl>http://janelia.org/</organizationUrl>
+			<roles>
+				<role>developer</role>
+				<role>maintainer </role>
+			</roles>
+			<timezone>-5</timezone>
+		</developer>
 		<developer>
 			<id>tpietzsch</id>
 			<name>Tobias Pietzsch</name>

--- a/src/main/java/net/imglib2/type/label/LabelMultisetEntryList.java
+++ b/src/main/java/net/imglib2/type/label/LabelMultisetEntryList.java
@@ -1,6 +1,7 @@
 package net.imglib2.type.label;
 
 import net.imglib2.type.label.LabelMultisetType.Entry;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -14,11 +15,31 @@ public class LabelMultisetEntryList
 		super(LabelMultisetEntry.type);
 	}
 
+	@Override public int hashCode() {
+
+		HashCodeBuilder builder = new HashCodeBuilder();
+		int hash1 = 13;
+		int hash2 = 31;
+		int hash = hash1;
+		for (final LabelMultisetEntry e  : this) {
+			builder.append(hash).append(e).append(e.getCount() * hash);
+			/* swap hash1 <==> hash2 */
+			hash = hash1;
+			hash1 = hash2;
+			hash2 = hash;
+			/* set hash to hash1 */
+			hash = hash1;
+    	}
+		return builder.toHashCode();
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (!(o instanceof LabelMultisetEntryList)) return false;
+		final LabelMultisetEntryList other = (LabelMultisetEntryList)o;
+		if (other.size() != size()) return false;
 		final long[] thisData = ((LongMappedAccessData) data).getData();
-		final long[] otherData = ((LongMappedAccessData) ((LabelMultisetEntryList) o).data).getData();
+		final long[] otherData = ((LongMappedAccessData) other.data).getData();
 		return Arrays.equals(thisData, otherData);
 	}
 

--- a/src/main/java/net/imglib2/type/label/LabelMultisetType.java
+++ b/src/main/java/net/imglib2/type/label/LabelMultisetType.java
@@ -392,6 +392,14 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 		return true;
 	}
 
+	@Override public boolean equals(Object obj) {
+
+		if (obj instanceof LabelMultisetType) {
+			return valueEquals((LabelMultisetType)obj);
+		}
+		return false;
+	}
+
 	public VolatileLabelMultisetArray getAccess() {
 
 		return this.access;

--- a/src/main/java/net/imglib2/type/label/LabelMultisetType.java
+++ b/src/main/java/net/imglib2/type/label/LabelMultisetType.java
@@ -220,7 +220,9 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 	}
 
 	public int listHashCode() {
-		return entrySet().hashCode();
+
+		entrySet();
+		return entries.hashCode();
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/label/MappedObjectArrayList.java
+++ b/src/main/java/net/imglib2/type/label/MappedObjectArrayList.java
@@ -234,12 +234,12 @@ public class MappedObjectArrayList<O extends MappedObject<O, T>, T extends Mappe
 		final int size = size();
 		ensureCapacity(size + 1);
 		setSize(size + 1);
+		setRefAt(ref, index);
 		if (index < size) {
 			final O shift = createRefAt(index + 1);
 			shift.access.copyFrom(ref.access, elementSizeInBytes() * (size - index));
 			releaseRef(shift);
 		}
-		setRefAt(ref, index);
 		ref.set(obj);
 	}
 

--- a/src/test/java/net/imglib2/type/label/SerializationTest.java
+++ b/src/test/java/net/imglib2/type/label/SerializationTest.java
@@ -2,32 +2,47 @@ package net.imglib2.type.label;
 
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.Converters;
+import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.list.ListImg;
 import net.imglib2.type.numeric.integer.IntType;
 import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.util.Fraction;
+import net.imglib2.util.Intervals;
 import net.imglib2.view.Views;
+import org.janelia.saalfeldlab.n5.N5FSWriter;
+import org.janelia.saalfeldlab.n5.N5Writer;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Random;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public class SerializationTest {
 
 	@Test
-	public void randomSerializationTest() {
+	public void randomSingleEntryImageSerializationTest() {
 
 		final Random rng = new Random();
 		final int dim = 32;
 		final long[] dims = {dim, dim, dim};
 		final RandomAccessibleInterval<LongType> img = ArrayImgs.longs(dims);
-		final int numElements = (int) Views.flatIterable(img).size();
-		Views.flatIterable(img).forEach(p -> p.set(rng.nextInt((int) Math.pow(dim, 3.0)/2)));
+		final int numElements = (int)Views.flatIterable(img).size();
+		Views.flatIterable(img).forEach(p -> p.set(rng.nextInt((int)Math.pow(dim, 3.0) / 2)));
 		final LabelMultisetType type = LabelMultisetType.singleEntryWithSingleOccurrence();
 		final RandomAccessibleInterval<LabelMultisetType> converted = Converters.convert2(img, new FromIntegerTypeConverter<>(), () -> type);
 
-		final byte[] serializedOut = LabelUtils.serializeLabelMultisetTypes(
-				Views.flatIterable(converted),
+		final byte[] serializedOut = serialize(
+				converted,
 				numElements);
 
 		final VolatileLabelMultisetArray arr = LabelUtils.fromBytes(serializedOut, numElements);
@@ -38,18 +53,17 @@ public class SerializationTest {
 
 	}
 
-
 	@Test
-	public void singleIdSerializationTest() {
+	public void singleIdImageSerializationTest() {
 
 		final long[] dims = {4, 4, 4};
 		final RandomAccessibleInterval<LongType> img = ArrayImgs.longs(dims);
 		final LabelMultisetType type = LabelMultisetType.singleEntryWithSingleOccurrence();
 		final RandomAccessibleInterval<LabelMultisetType> converted = Converters.convert2(img, new FromIntegerTypeConverter<>(), () -> type);
 
-		final int numElements = (int) Views.flatIterable(converted).size();
-		final byte[] serializedOut = LabelUtils.serializeLabelMultisetTypes(
-				Views.flatIterable(converted),
+		final int numElements = (int)Views.flatIterable(converted).size();
+		final byte[] serializedOut = serialize(
+				converted,
 				numElements);
 
 		final VolatileLabelMultisetArray arr = LabelUtils.fromBytes(serializedOut, numElements);
@@ -58,6 +72,123 @@ public class SerializationTest {
 
 		Assert.assertArrayEquals("Serialized bytes differed after deserialization", serializedOut, serializedOutAfterDeserialication);
 
+	}
+
+	@Test
+	public void randomMultipleEntryImageSerializationTest() throws IOException {
+
+		N5Writer n5 = new N5FSWriter(Files.createTempDirectory("n5-test").toString());
+		try {
+			final long[] dims = {10, 20, 30};
+			final Random rand = new Random();
+
+			final int numElements = (int)Intervals.numElements(dims);
+			final List<LabelMultisetType> typeElements = new ArrayList<>();
+			for (int i = 0; i < numElements; ++i) {
+				final int numEntries = rand.nextInt(10);
+				final LabelMultisetEntryList entries = new LabelMultisetEntryList(numEntries);
+				for (int j = 0; j < numEntries; ++j) {
+					final int id = rand.nextInt(10_000);
+					final int count = rand.nextInt(100);
+					entries.add(new LabelMultisetEntry(id, count));
+				}
+				typeElements.add(new LabelMultisetType(entries));
+			}
+			final ListImg<LabelMultisetType> originalImg = new ListImg<>(typeElements, dims);
+
+			final byte[] serializedOut = serialize(originalImg, numElements);
+
+			final VolatileLabelMultisetArray arr = LabelUtils.fromBytes(serializedOut, numElements);
+			final ArrayImg<LabelMultisetType, VolatileLabelMultisetArray> deserializedImg = new ArrayImg<>(arr, dims, new Fraction());
+			deserializedImg.setLinkedType(new LabelMultisetType(deserializedImg));
+
+			Assert.assertTrue(Intervals.equals(originalImg, deserializedImg));
+
+			final Iterator<LabelMultisetType> iterOverOriginalImg = Views.flatIterable(originalImg).iterator();
+			final Iterator<LabelMultisetType> iterOverDeserializedImg = Views.flatIterable(deserializedImg).iterator();
+			int i = -1;
+			while (iterOverOriginalImg.hasNext() || iterOverDeserializedImg.hasNext()) {
+				i++;
+				final LabelMultisetType original = iterOverOriginalImg.next();
+				final LabelMultisetType deserialized = iterOverDeserializedImg.next();
+				assertEquals(deserialized.argMax(), original.argMax());
+				assertEquals(deserialized.size(), original.size());
+				assertEquals(deserialized.entrySet().size(), original.entrySet().size());
+				final Iterator<LabelMultisetType.Entry<Label>> iterOverDeserializedEntries = original.entrySet().iterator();
+				final Iterator<LabelMultisetType.Entry<Label>> iterOverOriginalEntries = deserialized.entrySet().iterator();
+				while (iterOverDeserializedEntries.hasNext() || iterOverOriginalEntries.hasNext()) {
+					final LabelMultisetType.Entry<Label> expectedEntry = iterOverDeserializedEntries.next();
+					final LabelMultisetType.Entry<Label> actualEntry = iterOverOriginalEntries.next();
+					assertEquals(expectedEntry.getElement().id(), actualEntry.getElement().id());
+					assertEquals(actualEntry.getCount(), expectedEntry.getCount());
+				}
+			}
+
+		} finally {
+			n5.remove("");
+			n5.close();
+		}
+	}
+
+	@Test
+	public void randomMultipleEntrySingleTypeSerializationTest() throws IOException {
+
+		N5Writer n5 = new N5FSWriter(Files.createTempDirectory("n5-test").toString());
+		try {
+			final long[] dims = {1};
+			final int[] blockSize = {1};
+
+			final Random rand = new Random();
+
+			final int numElements = (int)Intervals.numElements(dims);
+			final List<LabelMultisetType> typeElements = new ArrayList<>();
+			for (int i = 0; i < numElements; ++i) {
+				final int numEntries = rand.nextInt(10);
+				final LabelMultisetEntryList entries = new LabelMultisetEntryList(numEntries);
+				for (int j = 0; j < numEntries; ++j) {
+					final int id = rand.nextInt(4);
+					final int count = rand.nextInt(10);
+					entries.add(new LabelMultisetEntry(id, count));
+				}
+				typeElements.add(new LabelMultisetType(entries));
+			}
+			final ListImg<LabelMultisetType> originalImg = new ListImg<>(typeElements, dims);
+
+			final byte[] serializedOut = serialize(originalImg, 2);
+
+			final VolatileLabelMultisetArray arr = LabelUtils.fromBytes(serializedOut, 1);
+			final ArrayImg<LabelMultisetType, VolatileLabelMultisetArray> deserializedImg = new ArrayImg<>(arr, dims, new Fraction());
+			deserializedImg.setLinkedType(new LabelMultisetType(deserializedImg));
+
+			final byte[] serializedOut2 = serialize(deserializedImg, (int)Intervals.numElements(deserializedImg));
+			assertArrayEquals(serializedOut, serializedOut2);
+
+			Assert.assertTrue(Intervals.equals(originalImg, deserializedImg));
+			final LabelMultisetType original = originalImg.firstElement();
+			final LabelMultisetType deserialized = deserializedImg.firstElement();
+			assertEquals(deserialized.argMax(), original.argMax());
+			assertEquals(deserialized.size(), original.size());
+			assertEquals(deserialized.entrySet().size(), original.entrySet().size());
+			final Iterator<LabelMultisetType.Entry<Label>> iterOverDeserializedEntries = original.entrySet().iterator();
+			final Iterator<LabelMultisetType.Entry<Label>> iterOverOriginalEntries = deserialized.entrySet().iterator();
+			while (iterOverDeserializedEntries.hasNext() || iterOverOriginalEntries.hasNext()) {
+				final LabelMultisetType.Entry<Label> expectedEntry = iterOverDeserializedEntries.next();
+				final LabelMultisetType.Entry<Label> actualEntry = iterOverOriginalEntries.next();
+				assertEquals(expectedEntry.getElement().id(), actualEntry.getElement().id());
+				assertEquals(actualEntry.getCount(), expectedEntry.getCount());
+			}
+
+		} finally {
+			n5.remove("");
+			n5.close();
+		}
+	}
+
+	private static byte[] serialize(RandomAccessibleInterval<LabelMultisetType> img, int numElements) {
+
+		return LabelUtils.serializeLabelMultisetTypes(
+				Views.flatIterable(img),
+				numElements);
 	}
 
 	@Test
@@ -69,10 +200,8 @@ public class SerializationTest {
 		Views.flatIterable(img).forEach(p -> p.set(Label.INVALID));
 		final RandomAccessibleInterval<LabelMultisetType> converted = Converters.convert2(img, new FromIntegerTypeConverter<>(), () -> type);
 
-		final int numElements = (int) Views.flatIterable(converted).size();
-		final byte[] serializedOut = LabelUtils.serializeLabelMultisetTypes(
-				Views.flatIterable(converted),
-				numElements);
+		final int numElements = (int)Views.flatIterable(converted).size();
+		final byte[] serializedOut = serialize(converted, numElements);
 
 		final VolatileLabelMultisetArray arr = LabelUtils.fromBytes(serializedOut, numElements);
 		final byte[] serializedOutAfterDeserialication = new byte[LabelMultisetTypeDownscaler.getSerializedVolatileLabelMultisetArraySize(arr)];
@@ -92,8 +221,8 @@ public class SerializationTest {
 		final LabelMultisetType two = one.copy();
 		intToLmt.convert(new IntType(2), two);
 
-		Assert.assertEquals(1, one.getIntegerLong());
-		Assert.assertEquals(2, two.getIntegerLong());
+		assertEquals(1, one.getIntegerLong());
+		assertEquals(2, two.getIntegerLong());
 
 	}
 


### PR DESCRIPTION
A regression was introduced in 0.12.0 when resolving a separate bug. 
Tests in imglib2-label-multisets did not catch the regression, but it was caught by a test in [n5-imglib2](https://github.com/saalfeldlab/n5-imglib2/blob/2da3143597a37014a318e9c01d407fb1e8ac53b2/src/test/java/org/janelia/saalfeldlab/n5/imglib2/N5LabelMultisetsTest.java#L103) when attempting to bump the dependency version.

The test was from [n5-imglib2](https://github.com/saalfeldlab/n5-imglib2/blob/2da3143597a37014a318e9c01d407fb1e8ac53b2/src/test/java/org/janelia/saalfeldlab/n5/imglib2/N5LabelMultisetsTest.java#L103) was added to [n5-imglib2-label-multisets](https://github.com/saalfeldlab/imglib2-label-multisets/commit/82947c8fce3cb100997612020812de39d2995b34).

some other bug fixes:
- reduced hash collision when comparing entry lists
- shifting entries when inserting a new entry was shifting from the wrong index