### PR TITLE
Feat/more implementations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,10 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-imglib2</artifactId>
 			<scope>test</scope>

--- a/src/main/java/net/imglib2/type/label/LabelMultisetEntryList.java
+++ b/src/main/java/net/imglib2/type/label/LabelMultisetEntryList.java
@@ -8,6 +8,11 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
 
+/**
+ * List of LabelMultisetEntries backed by a LongArray. Should ALWAYS remain sorted by ID. It is sorted after construction, and
+ * all add operations should insert appropriately to remain sorted. If `sortByCount` is ever called (or the order is manually changed)
+ * it is the developers responsiblity to `sortById()` prior to any additional calls.
+ */
 public class LabelMultisetEntryList extends MappedObjectArrayList<LabelMultisetEntry, LongMappedAccess> {
 
 	public LabelMultisetEntryList() {
@@ -51,6 +56,7 @@ public class LabelMultisetEntryList extends MappedObjectArrayList<LabelMultisetE
 	public LabelMultisetEntryList(final LongMappedAccessData data, final long baseOffset) {
 
 		super(LabelMultisetEntry.type, data, baseOffset);
+		sortById();
 	}
 
 	protected int multisetSize() {
@@ -72,13 +78,6 @@ public class LabelMultisetEntryList extends MappedObjectArrayList<LabelMultisetE
 
 	@Override public boolean add(LabelMultisetEntry obj, LabelMultisetEntry ref) {
 
-		sortById();
-		addAfterSort(obj, ref);
-		return true;
-	}
-
-	private void addAfterSort(LabelMultisetEntry obj, LabelMultisetEntry ref) {
-
 		final int idx = binarySearch(obj.getId(), ref);
 		if (idx >= 0) {
 			final LabelMultisetEntry entry = get(idx, ref);
@@ -86,14 +85,14 @@ public class LabelMultisetEntryList extends MappedObjectArrayList<LabelMultisetE
 		} else {
 			add(-(idx + 1), obj, ref);
 		}
+		return true;
 	}
 
 	@Override public boolean addAll(Collection<? extends LabelMultisetEntry> c) {
 
-		sortById();
 		final LabelMultisetEntry ref = createRef();
 		for (LabelMultisetEntry entry : c) {
-			addAfterSort(entry, ref);
+			add(entry, ref);
 		}
 		return true;
 	}
@@ -102,9 +101,8 @@ public class LabelMultisetEntryList extends MappedObjectArrayList<LabelMultisetE
 
 	@Override public boolean addAll(Collection<? extends LabelMultisetEntry> c, LabelMultisetEntry ref) {
 
-		sortById();
 		for (LabelMultisetEntry entry : c) {
-			addAfterSort(entry, ref);
+			add(entry, ref);
 		}
 		return true;
 	}

--- a/src/main/java/net/imglib2/type/label/LabelMultisetEntryList.java
+++ b/src/main/java/net/imglib2/type/label/LabelMultisetEntryList.java
@@ -4,11 +4,11 @@ import net.imglib2.type.label.LabelMultisetType.Entry;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
 
-public class LabelMultisetEntryList
-		extends MappedObjectArrayList<LabelMultisetEntry, LongMappedAccess> {
+public class LabelMultisetEntryList extends MappedObjectArrayList<LabelMultisetEntry, LongMappedAccess> {
 
 	public LabelMultisetEntryList() {
 
@@ -60,6 +60,53 @@ public class LabelMultisetEntryList
 			size += e.getCount();
 		}
 		return size;
+	}
+
+	@Override public boolean add(LabelMultisetEntry obj) {
+
+		final LabelMultisetEntry ref = createRef();
+		add(obj ,ref);
+		releaseRef(ref);
+		return true;
+	}
+
+	@Override public boolean add(LabelMultisetEntry obj, LabelMultisetEntry ref) {
+
+		sortById();
+		addAfterSort(obj, ref);
+		return true;
+	}
+
+	private void addAfterSort(LabelMultisetEntry obj, LabelMultisetEntry ref) {
+
+		final int idx = binarySearch(obj.getId(), ref);
+		if (idx >= 0) {
+			final LabelMultisetEntry entry = get(idx, ref);
+			entry.setCount(entry.getCount() + obj.getCount());
+		} else {
+			add(-(idx + 1), obj, ref);
+		}
+	}
+
+	@Override public boolean addAll(Collection<? extends LabelMultisetEntry> c) {
+
+		sortById();
+		final LabelMultisetEntry ref = createRef();
+		for (LabelMultisetEntry entry : c) {
+			addAfterSort(entry, ref);
+		}
+		return true;
+	}
+
+
+
+	@Override public boolean addAll(Collection<? extends LabelMultisetEntry> c, LabelMultisetEntry ref) {
+
+		sortById();
+		for (LabelMultisetEntry entry : c) {
+			addAfterSort(entry, ref);
+		}
+		return true;
 	}
 
 	/**
@@ -162,13 +209,24 @@ public class LabelMultisetEntryList
 	/**
 	 * Sort the list by {@link LabelMultisetEntry#getId()}.
 	 */
-	// TODO: should this be protected / package private?
 	public void sortById() {
 
 		sort((o1, o2) -> {
 			final long i1 = o1.getId();
 			final long i2 = o2.getId();
 			return Long.compare(i1, i2);
+		});
+	}
+
+	/**
+	 * Sort the list by {@link LabelMultisetEntry#getId()}.
+	 */
+	public void sortByCount() {
+
+		sort((o1, o2) -> {
+			final int i1 = o1.getCount();
+			final int i2 = o2.getCount();
+			return Integer.compare(i1, i2);
 		});
 	}
 

--- a/src/main/java/net/imglib2/type/label/LabelMultisetType.java
+++ b/src/main/java/net/imglib2/type/label/LabelMultisetType.java
@@ -330,21 +330,18 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 	public boolean contains(final long id, LabelMultisetEntry ref) {
 
 		updateEntriesLocation();
-		entries.sortById();
 		return entries.binarySearch(id, ref) >= 0;
 	}
 
 	public boolean contains(final long id) {
 
 		updateEntriesLocation();
-		entries.sortById();
 		return entries.binarySearch(id) >= 0;
 	}
 
 	public boolean containsAll(final long[] ids) {
 
 		updateEntriesLocation();
-		entries.sortById();
 		for (final long id : ids) {
 			if (entries.binarySearch(id) < 0) {
 				return false;
@@ -356,7 +353,6 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 	public boolean containsAll(final long[] ids, LabelMultisetEntry ref) {
 
 		updateEntriesLocation();
-		entries.sortById();
 		for (final long id : ids) {
 			if (entries.binarySearch(id, ref) < 0) {
 				return false;
@@ -368,7 +364,6 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 	public boolean containsAll(final Collection<? extends Label> c) {
 
 		updateEntriesLocation();
-		entries.sortById();
 		for (final Label l : c) {
 			if (entries.binarySearch(l.id()) < 0) {
 				return false;
@@ -380,7 +375,6 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 	public boolean containsAll(final Collection<? extends Label> c, LabelMultisetEntry ref) {
 
 		updateEntriesLocation();
-		entries.sortById();
 		for (final Label l : c) {
 			if (entries.binarySearch(l.id(), ref) < 0) {
 				return false;
@@ -397,7 +391,6 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 	public int count(final long id) {
 
 		updateEntriesLocation();
-		entries.sortById();
 		final int pos = entries.binarySearch(id);
 		if (pos < 0) {
 			return 0;
@@ -409,7 +402,6 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 	public int countWithRef(final long id, LabelMultisetEntry ref) {
 
 		updateEntriesLocation();
-		entries.sortById();
 		final int pos = entries.binarySearch(id, ref);
 		if (pos < 0) {
 			return 0;

--- a/src/main/java/net/imglib2/type/label/LabelMultisetType.java
+++ b/src/main/java/net/imglib2/type/label/LabelMultisetType.java
@@ -155,7 +155,6 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 		};
 		if (this.access != null) {
 			updateEntriesLocation();
-			updateArgMax();
 		}
 	}
 
@@ -166,8 +165,11 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 
 	public void add(LabelMultisetEntry entry) {
 
-		labelMultisetEntries().add(entry);
-		updateArgMax();
+		final Label id = entry.id;
+		final LabelMultisetEntryList lmel = labelMultisetEntries();
+		lmel.add(entry);
+		if (count(id) > count(argMax()))
+			updateArgMax(id.id());
 	}
 
 	public void addAll(Collection<? extends LabelMultisetEntry> entries) {
@@ -204,9 +206,6 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 	public void updateContainer(final Object c) {
 
 		access = img.update(c);
-		if (index().get() >= 0) {
-			updateArgMax();
-		}
 	}
 
 	@Override
@@ -708,7 +707,12 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 
 	public void updateArgMax() {
 
-		this.access.setArgMax(i.get(), LabelUtils.getArgMax(labelMultisetEntries()));
+		updateArgMax(LabelUtils.getArgMax(labelMultisetEntries()));
+	}
+
+	public void updateArgMax(long id) {
+
+		this.access.setArgMax(i.get(), id);
 	}
 
 	public static LabelMultisetType singleEntryWithSingleOccurrence() {

--- a/src/main/java/net/imglib2/type/label/LabelMultisetType.java
+++ b/src/main/java/net/imglib2/type/label/LabelMultisetType.java
@@ -1,18 +1,24 @@
 package net.imglib2.type.label;
 
+import net.imglib2.Interval;
 import net.imglib2.img.NativeImg;
+import net.imglib2.img.cell.CellGrid;
 import net.imglib2.type.AbstractNativeType;
 import net.imglib2.type.Index;
 import net.imglib2.type.NativeTypeFactory;
 import net.imglib2.type.label.RefList.RefIterator;
 import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.util.Fraction;
+import net.imglib2.util.Intervals;
 
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.util.AbstractSet;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> implements IntegerType<LabelMultisetType> {
@@ -26,13 +32,15 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 
 	public static final LabelMultisetType type = new LabelMultisetType();
 
-	private final NativeImg<?, VolatileLabelMultisetArray> img;
+	private NativeImg<?, VolatileLabelMultisetArray> img;
 
 	private VolatileLabelMultisetArray access;
 
 	private final LabelMultisetEntryList entries;
 
 	private final Set<Entry<Label>> entrySet;
+
+	private LabelMultisetEntry reference = null;
 
 	// this is the constructor if you want it to read from an array
 	public LabelMultisetType(final NativeImg<?, VolatileLabelMultisetArray> img) {
@@ -56,23 +64,19 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 	public LabelMultisetType(final LabelMultisetEntry entry) {
 
 		this();
-		this.entries.add(entry);
-		this.access.setArgMax(i.get(), entry.getId());
+		add(entry);
 	}
 
 	// this is the constructor if you want it to be a variable
 	public LabelMultisetType(final LabelMultisetEntryList entries) {
 
 		this();
-		this.entries.addAll(entries);
-		updateArgMax();
+		addAll(entries);
 	}
 
 	private LabelMultisetType(final NativeImg<?, VolatileLabelMultisetArray> img, final VolatileLabelMultisetArray access) {
 		this(img, access, 0);
 	}
-
-	private LabelMultisetEntry reference = null;
 
 	private LabelMultisetType(final NativeImg<?, VolatileLabelMultisetArray> img, final VolatileLabelMultisetArray access, final int idx) {
 
@@ -96,9 +100,6 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 		this.access = access;
 		this.i.set(idx);
 
-		if (this.access != null) {
-			this.access.getValue(i.get(), this.entries);
-		}
 		this.entrySet = new AbstractSet<Entry<Label>>() {
 
 			private final RefIterator<Entry<Label>> iterator = new RefIterator<Entry<Label>>() {
@@ -116,7 +117,6 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 
 					return it.next();
 				}
-
 
 
 				@Override
@@ -148,19 +148,50 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 			}
 
 			@Override
-			public Stream<Entry<Label>> stream() {
-
-
-
-				throw new UnsupportedOperationException("Streams are not compatible with " + getClass().getName() + " because its iterator reuses the same reference.");
-			}
-
-			@Override
 			public Stream<Entry<Label>> parallelStream() {
 
 				throw new UnsupportedOperationException("Streams are not compatible with " + getClass().getName() + " because its iterator reuses the same reference.");
 			}
 		};
+		if (this.access != null) {
+			updateEntriesLocation();
+			updateArgMax();
+		}
+	}
+
+	public void add(final long id, final int count) {
+
+		add(new LabelMultisetEntry(id, count));
+	}
+
+	public void add(LabelMultisetEntry entry) {
+
+		labelMultisetEntries().add(entry);
+		updateArgMax();
+	}
+
+	public void addAll(Collection<? extends LabelMultisetEntry> entries) {
+
+		labelMultisetEntries().addAll(entries);
+		updateArgMax();
+	}
+
+	public void set(final long id, final int count) {
+
+		labelMultisetEntries().clear();
+		add(id, count);
+	}
+
+	public void set(Collection<? extends LabelMultisetEntry> entries) {
+
+		labelMultisetEntries().clear();
+		addAll(entries);
+	}
+
+	public void clear() {
+
+		labelMultisetEntries().clear();
+		updateArgMax();
 	}
 
 	@Override
@@ -173,6 +204,9 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 	public void updateContainer(final Object c) {
 
 		access = img.update(c);
+		if (index().get() >= 0) {
+			updateArgMax();
+		}
 	}
 
 	@Override
@@ -188,9 +222,7 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 		if (img != null) {
 			/* If backed by an image, copy the entries only, not the entire backing data. */
 			final LabelMultisetType labelMultisetType = new LabelMultisetType();
-			entrySet();
-			labelMultisetType.entrySet();
-			labelMultisetType.entries.addAll(entries);
+			labelMultisetType.labelMultisetEntries().addAll(labelMultisetEntries());
 			return labelMultisetType;
 		} else {
 			/* copy the listData */
@@ -215,20 +247,49 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 			final LabelMultisetType that = new LabelMultisetType(null, accessCopy);
 			return that;
 		}
-
-
 	}
 
 	public int listHashCode() {
-
-		entrySet();
-		return entries.hashCode();
+		return labelMultisetEntries().hashCode();
 	}
 
 	@Override
 	public void set(final LabelMultisetType c) {
 
-		throw new UnsupportedOperationException();
+		if (c.img != null) {
+			/* If backed by an image, copy the entries only, not the entire backing data. */
+
+			img = null;
+			i.set(0);
+			clear();
+
+			addAll(c.labelMultisetEntries());
+		} else {
+			/* copy the listData */
+			final long byteSize = c.access.getListData().size();
+			final int longSize = c.access.getListData().data.length;
+			final LongMappedAccessData listDataCopy = LongMappedAccessData.factory.createStorage(byteSize);
+			System.arraycopy(c.access.getListData().data, 0, listDataCopy.data, 0, longSize);
+
+			/* copy the data */
+			final int[] data = c.access.getCurrentStorageArray();
+			final int[] dataCopy = new int[data.length];
+			System.arraycopy(data, 0, dataCopy, 0, data.length);
+
+			/* get a new access with all the copies */
+			final VolatileLabelMultisetArray accessCopy = new VolatileLabelMultisetArray(
+					dataCopy,
+					listDataCopy,
+					c.access.getListDataUsedSizeInBytes(),
+					c.access.isValid(),
+					c.access.argMaxCopy());
+			/* get a new type instance */
+
+			img = null;
+			i.set(0);
+			access = accessCopy;
+			updateEntriesLocation();
+		}
 	}
 
 	@Override
@@ -247,14 +308,13 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 
 	public int size() {
 
-		access.getValue(i.get(), entries);
+		updateEntriesLocation();
 		return entries.multisetSize();
 	}
 
 	public boolean isEmpty() {
 
-		access.getValue(i.get(), entries);
-		return entries.isEmpty();
+		return labelMultisetEntries().isEmpty();
 	}
 
 	public boolean contains(final Label l, LabelMultisetEntry ref) {
@@ -269,19 +329,22 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 
 	public boolean contains(final long id, LabelMultisetEntry ref) {
 
-		access.getValue(i.get(), entries);
+		updateEntriesLocation();
+		entries.sortById();
 		return entries.binarySearch(id, ref) >= 0;
 	}
 
 	public boolean contains(final long id) {
 
-		access.getValue(i.get(), entries);
+		updateEntriesLocation();
+		entries.sortById();
 		return entries.binarySearch(id) >= 0;
 	}
 
 	public boolean containsAll(final long[] ids) {
 
-		access.getValue(i.get(), entries);
+		updateEntriesLocation();
+		entries.sortById();
 		for (final long id : ids) {
 			if (entries.binarySearch(id) < 0) {
 				return false;
@@ -292,7 +355,8 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 
 	public boolean containsAll(final long[] ids, LabelMultisetEntry ref) {
 
-		access.getValue(i.get(), entries);
+		updateEntriesLocation();
+		entries.sortById();
 		for (final long id : ids) {
 			if (entries.binarySearch(id, ref) < 0) {
 				return false;
@@ -303,7 +367,8 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 
 	public boolean containsAll(final Collection<? extends Label> c) {
 
-		access.getValue(i.get(), entries);
+		updateEntriesLocation();
+		entries.sortById();
 		for (final Label l : c) {
 			if (entries.binarySearch(l.id()) < 0) {
 				return false;
@@ -314,7 +379,8 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 
 	public boolean containsAll(final Collection<? extends Label> c, LabelMultisetEntry ref) {
 
-		access.getValue(i.get(), entries);
+		updateEntriesLocation();
+		entries.sortById();
 		for (final Label l : c) {
 			if (entries.binarySearch(l.id(), ref) < 0) {
 				return false;
@@ -330,7 +396,8 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 
 	public int count(final long id) {
 
-		access.getValue(i.get(), entries);
+		updateEntriesLocation();
+		entries.sortById();
 		final int pos = entries.binarySearch(id);
 		if (pos < 0) {
 			return 0;
@@ -341,7 +408,8 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 
 	public int countWithRef(final long id, LabelMultisetEntry ref) {
 
-		access.getValue(i.get(), entries);
+		updateEntriesLocation();
+		entries.sortById();
 		final int pos = entries.binarySearch(id, ref);
 		if (pos < 0) {
 			return 0;
@@ -352,7 +420,7 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 
 	public Set<Entry<Label>> entrySet() {
 
-		access.getValue(i.get(), entries);
+		updateEntriesLocation();
 		return entrySet;
 	}
 
@@ -361,10 +429,20 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 		return entrySet();
 	}
 
+	LabelMultisetEntryList labelMultisetEntries() {
+		entrySet();
+		return entries;
+	}
+
+	private void updateEntriesLocation() {
+
+		access.getValue(i.get(), entries);
+	}
+
 	@Override
 	public String toString() {
 
-		access.getValue(i.get(), entries);
+		updateEntriesLocation();
 		return entries.toString();
 	}
 
@@ -377,12 +455,14 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 	@Override
 	public boolean valueEquals(final LabelMultisetType other) {
 
-		if (entries.size() != other.entries.size()) {
+		final LabelMultisetEntryList lmel = labelMultisetEntries();
+		final LabelMultisetEntryList otherLmel = other.labelMultisetEntries();
+		if (lmel.size() != otherLmel.size()) {
 			return false;
 		}
 
-		final RefIterator<LabelMultisetEntry> ai = entries.iterator();
-		final RefIterator<LabelMultisetEntry> bi = other.entries.iterator();
+		final RefIterator<LabelMultisetEntry> ai = lmel.iterator();
+		final RefIterator<LabelMultisetEntry> bi = otherLmel.iterator();
 
 		while (ai.hasNext()) {
 			final LabelMultisetEntry a = ai.next();
@@ -422,7 +502,7 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 	@Override
 	public double getMaxValue() {
 
-		throw new UnsupportedOperationException();
+		return argMax();
 	}
 
 	@Override
@@ -446,13 +526,13 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 	@Override
 	public double getRealDouble() {
 
-		return getIntegerLong();
+		return argMax();
 	}
 
 	@Override
 	public float getRealFloat() {
 
-		return getIntegerLong();
+		return argMax();
 	}
 
 	@Override
@@ -536,7 +616,7 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 	@Override
 	public void add(final LabelMultisetType c) {
 
-		throw new UnsupportedOperationException();
+		addAll(c.labelMultisetEntries());
 	}
 
 	@Override
@@ -560,13 +640,13 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 	@Override
 	public void setOne() {
 
-		throw new UnsupportedOperationException();
+		set(1, 1);
 	}
 
 	@Override
 	public void setZero() {
 
-		throw new UnsupportedOperationException();
+		set(0, 1);
 	}
 
 	@Override
@@ -584,7 +664,12 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 	@Override
 	public int compareTo(final LabelMultisetType arg0) {
 
-		throw new UnsupportedOperationException();
+		final long ours = argMax();
+		final long theirs = arg0.argMax();
+		final int initialComparison = Long.compare(ours, theirs);
+
+		if (initialComparison != 0) return initialComparison;
+		else return Long.compare(count(ours), count(theirs));
 	}
 
 	@Override
@@ -609,13 +694,13 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 	@Override
 	public void setInteger(final int f) {
 
-		throw new UnsupportedOperationException();
+		set(f, 1);
 	}
 
 	@Override
 	public void setInteger(final long f) {
 
-		throw new UnsupportedOperationException();
+		set(f, 1);
 	}
 
 	@Override
@@ -631,7 +716,7 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 
 	public void updateArgMax() {
 
-		this.access.setArgMax(i.get(), LabelUtils.getArgMax(entrySet()));
+		this.access.setArgMax(i.get(), LabelUtils.getArgMax(labelMultisetEntries()));
 	}
 
 	public static LabelMultisetType singleEntryWithSingleOccurrence() {
@@ -654,5 +739,46 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 	public void pow(final double d) {
 
 		throw new UnsupportedOperationException();
+	}
+
+	public static class EmptyLabelMultisetTypeGenerator implements BiFunction<CellGrid, long[], byte[]> {
+
+		private static int numElements(final int[] size) {
+
+			int n = 1;
+			for (final int s : size)
+				n *= s;
+			return n;
+		}
+		@Override
+		public byte[] apply(final CellGrid cellGrid, final long[] cellPos) {
+
+			final long[] cellMin = new long[cellPos.length];
+			final int[] cellDims = new int[cellMin.length];
+			Arrays.setAll(cellMin, d -> cellPos[d] * cellGrid.cellDimension(d));
+			cellGrid.getCellDimensions(cellPos, cellMin, cellDims);
+			final int numElements = numElements(cellDims);
+
+			final LongMappedAccessData listData = LongMappedAccessData.factory.createStorage(0);
+			final LabelMultisetEntryList list = new LabelMultisetEntryList(listData, 0);
+			list.createListAt(listData, 0);
+			final int listSize = (int)list.getSizeInBytes();
+
+			final byte[] bytes = new byte[Integer.BYTES
+					+ numElements * Long.BYTES // for argmaxes
+					+ numElements * Integer.BYTES // for mappings
+					+ listSize // for actual entries (one single entry)
+					];
+
+			final ByteBuffer bb = ByteBuffer.wrap(bytes);
+
+			// argmax
+			bb.putInt(numElements);
+			for (int i = 0; i < listSize; ++i) {
+				// ByteUtils.putByte( bb.get(), listData.data, i );
+				bb.put(ByteUtils.getByte(listData.getData(), i));
+			}
+			return bytes;
+		}
 	}
 }

--- a/src/main/java/net/imglib2/type/label/LabelMultisetTypeDownscaler.java
+++ b/src/main/java/net/imglib2/type/label/LabelMultisetTypeDownscaler.java
@@ -1,6 +1,5 @@
 package net.imglib2.type.label;
 
-import gnu.trove.impl.Constants;
 import gnu.trove.list.array.TIntArrayList;
 import gnu.trove.list.array.TLongArrayList;
 import gnu.trove.map.hash.TIntObjectHashMap;

--- a/src/main/java/net/imglib2/type/label/LabelUtils.java
+++ b/src/main/java/net/imglib2/type/label/LabelUtils.java
@@ -151,13 +151,21 @@ public class LabelUtils {
 		return new VolatileLabelMultisetArray(listEntryOffsets, listData, listDataSize, true, argMax);
 	}
 
+	/**
+	 * find the entry whose id has the highest count. If multiple entries has the same count, the
+	 * lowest id is considered the argmax.
+	 *
+	 * @param labelMultisetEntries to search for the argmax in
+	 * @return the id with the highest count
+	 */
 	public static long getArgMax(final Collection<? extends Entry<Label>> labelMultisetEntries) {
 
 		int maxCount = 0;
 		long maxCountId = Label.INVALID;
 		for (final Entry<Label> entry : labelMultisetEntries) {
-			if (maxCount < entry.getCount()) {
-				maxCount = entry.getCount();
+			final int count = entry.getCount();
+			if (maxCount < count || maxCount == count && entry.getElement().id() < maxCountId) {
+				maxCount = count;
 				maxCountId = entry.getElement().id();
 			}
 		}

--- a/src/test/java/net/imglib2/type/label/LabelMultisetTypeDownscalerTest.java
+++ b/src/test/java/net/imglib2/type/label/LabelMultisetTypeDownscalerTest.java
@@ -64,7 +64,7 @@ public class LabelMultisetTypeDownscalerTest {
 
 	private static RandomAccessibleInterval<LabelMultisetType> generateRandomLabelMultisetImg() {
 
-		final Random rnd = new Random();
+		final Random rnd = new Random(10);
 
 		final int numElements = (int) Intervals.numElements(DIMENSIONS);
 		final List<LabelMultisetType> typeElements = new ArrayList<>();

--- a/src/test/java/net/imglib2/type/label/LabelMultisetTypeTest.java
+++ b/src/test/java/net/imglib2/type/label/LabelMultisetTypeTest.java
@@ -1,20 +1,251 @@
 package net.imglib2.type.label;
 
+import com.google.common.collect.Streams;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Random;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
 
 public class LabelMultisetTypeTest {
 
-	private static final Random rnd = new Random();
+	private static final Random rnd = new Random(10);
+
+	@Test
+	public void addEntries() {
+
+		final LabelMultisetType lmt = new LabelMultisetType();
+		lmt.add(1, 1);
+		lmt.add(2, 1);
+		lmt.add(3, 1);
+		lmt.add(4, 1);
+		assertEquals(4, lmt.size());
+
+		Streams.forEachPair(
+				lmt.entrySet().stream(),
+				Stream.of(
+						new LabelMultisetEntry(1, 1),
+						new LabelMultisetEntry(2, 1),
+						new LabelMultisetEntry(3, 1),
+						new LabelMultisetEntry(4, 1)
+				),
+				(actual, expected) -> {
+					assertEquals(expected, actual);
+				}
+		);
+	}
+
+	@Test
+	public void setEntries() {
+
+		final LabelMultisetType lmt = new LabelMultisetType();
+		lmt.add(1, 1);
+		lmt.add(2, 1);
+		lmt.add(3, 1);
+		lmt.set(4, 1);
+		assertEquals(1, lmt.size());
+
+		Streams.forEachPair(
+				lmt.entrySet().stream(),
+				Stream.of(
+						new LabelMultisetEntry(4, 1)
+				),
+				(actual, expected) -> {
+					assertEquals(expected, actual);
+				}
+		);
+	}
+
+	@Test
+	public void addType() {
+
+		final LabelMultisetType lmt = new LabelMultisetType();
+		lmt.add(1, 1);
+		lmt.add(2, 1);
+		lmt.add(3, 1);
+		lmt.add(4, 1);
+		final LabelMultisetType lmt2 = new LabelMultisetType();
+		lmt2.add(1, 1);
+		lmt2.add(2, 1);
+		lmt2.add(3, 1);
+		lmt2.add(4, 1);
+
+		assertEquals(4, lmt.size());
+		lmt.add(lmt2);
+		assertEquals("Total count of all entries is 8", 8, lmt.size());
+
+		Streams.forEachPair(
+				lmt2.entrySet().stream(),
+				Stream.of(
+						new LabelMultisetEntry(1, 1),
+						new LabelMultisetEntry(2, 1),
+						new LabelMultisetEntry(3, 1),
+						new LabelMultisetEntry(4, 1)
+				),
+				(actual, expected) -> {
+					assertEquals(expected, actual);
+				}
+		);
+
+		Streams.forEachPair(
+				lmt.entrySet().stream(),
+				Stream.of(
+						new LabelMultisetEntry(1, 2),
+						new LabelMultisetEntry(2, 2),
+						new LabelMultisetEntry(3, 2),
+						new LabelMultisetEntry(4, 2)
+				),
+				(actual, expected) -> {
+					assertEquals(expected, actual);
+				}
+		);
+	}
+
+	@Test
+	public void setType() {
+
+		final LabelMultisetType lmt = new LabelMultisetType();
+		final LabelMultisetType lmt2 = new LabelMultisetType();
+		lmt2.add(1, 1);
+		lmt2.add(2, 1);
+		lmt2.add(3, 1);
+		lmt2.add(4, 1);
+
+		lmt.set(lmt2);
+		Streams.forEachPair(
+				lmt.entrySet().stream(),
+				Stream.of(
+						new LabelMultisetEntry(1, 1),
+						new LabelMultisetEntry(2, 1),
+						new LabelMultisetEntry(3, 1),
+						new LabelMultisetEntry(4, 1)
+				),
+				(actual, expected) -> {
+					assertEquals(expected, actual);
+				}
+		);
+
+		Streams.forEachPair(
+				lmt.entrySet().stream(),
+				lmt2.entrySet().stream(),
+				(actual, expected) -> {
+					assertEquals(expected, actual);
+				}
+		);
+	}
+
+	@Test
+	public void addAll() {
+
+		final LabelMultisetEntry lme1 = new LabelMultisetEntry(1, 1);
+		final LabelMultisetEntry lme2 = new LabelMultisetEntry(2, 1);
+		final LabelMultisetEntry lme3 = new LabelMultisetEntry(3, 1);
+		final LabelMultisetEntry lme4 = new LabelMultisetEntry(4, 1);
+
+		final LabelMultisetEntryList lmel = new LabelMultisetEntryList(4);
+		lmel.add(lme1);
+		lmel.add(lme2);
+		lmel.add(lme3);
+		lmel.add(lme4);
+
+		final List<LabelMultisetEntry> list = new ArrayList<>();
+		list.add(lme1);
+		list.add(lme2);
+		list.add(lme3);
+		list.add(lme4);
+
+		List<List<LabelMultisetEntry>> lists = new ArrayList<>();
+		lists.add(lmel);
+		lists.add(list);
+		for (List<LabelMultisetEntry> entries : lists) {
+			final LabelMultisetType lmt = new LabelMultisetType();
+			lmt.addAll(entries);
+			assertEquals(4, lmt.size());
+
+			Streams.forEachPair(
+					lmt.entrySet().stream(),
+					Stream.of(
+							new LabelMultisetEntry(1, 1),
+							new LabelMultisetEntry(2, 1),
+							new LabelMultisetEntry(3, 1),
+							new LabelMultisetEntry(4, 1)
+					),
+					(actual, expected) -> {
+						assertEquals(expected, actual);
+					}
+			);
+		}
+	}
+
+	@Test
+	public void setAll() {
+
+		final LabelMultisetEntry lme1 = new LabelMultisetEntry(1, 1);
+		final LabelMultisetEntry lme2 = new LabelMultisetEntry(2, 1);
+		final LabelMultisetEntry lme3 = new LabelMultisetEntry(3, 1);
+		final LabelMultisetEntry lme4 = new LabelMultisetEntry(4, 1);
+
+		final LabelMultisetEntryList lmel = new LabelMultisetEntryList(4);
+		lmel.add(lme1);
+		lmel.add(lme2);
+		lmel.add(lme3);
+		lmel.add(lme4);
+
+		final List<LabelMultisetEntry> list = new ArrayList<>();
+		list.add(lme1);
+		list.add(lme2);
+		list.add(lme3);
+		list.add(lme4);
+
+		final LabelMultisetType lmt = new LabelMultisetType();
+		List<List<LabelMultisetEntry>> lists = new ArrayList<>();
+		lists.add(lmel);
+		lists.add(list);
+		for (List<LabelMultisetEntry> entries : lists) {
+			lmt.set(entries);
+			assertEquals(4, lmt.size());
+
+			Streams.forEachPair(
+					lmt.entrySet().stream(),
+					Stream.of(
+							new LabelMultisetEntry(1, 1),
+							new LabelMultisetEntry(2, 1),
+							new LabelMultisetEntry(3, 1),
+							new LabelMultisetEntry(4, 1)
+					),
+					(actual, expected) -> assertEquals(expected, actual)
+			);
+		}
+	}
+
+	@Test
+	public void testClearEntries() {
+
+		final LabelMultisetType lmtEmpty = new LabelMultisetType();
+		assertEquals(Label.INVALID, lmtEmpty.argMax());
+		Assert.assertTrue(lmtEmpty.isEmpty());
+
+		final LabelMultisetEntry entry = new LabelMultisetEntry(1, 1);
+		lmtEmpty.add(entry);
+		assertEquals(lmtEmpty.entrySet().iterator().next(), entry);
+
+		lmtEmpty.clear();
+		assertEquals(Label.INVALID, lmtEmpty.argMax());
+		Assert.assertTrue(lmtEmpty.isEmpty());
+	}
 
 	@Test
 	public void testInitializationEmpty() {
 
 		final LabelMultisetType lmtEmpty = new LabelMultisetType();
-		Assert.assertEquals(Label.INVALID, lmtEmpty.argMax());
+		assertEquals(Label.INVALID, lmtEmpty.argMax());
 		Assert.assertTrue(lmtEmpty.isEmpty());
 	}
 
@@ -22,27 +253,35 @@ public class LabelMultisetTypeTest {
 	public void testInitializationSingleEntry() {
 
 		final LabelMultisetType lmtSingleEntry = new LabelMultisetType(new LabelMultisetEntry(5, 2));
-		Assert.assertEquals(5, lmtSingleEntry.argMax());
-		Assert.assertEquals(2, lmtSingleEntry.size());
-		Assert.assertEquals(1, lmtSingleEntry.entrySet().size());
+		assertEquals(5, lmtSingleEntry.argMax());
+		assertEquals(2, lmtSingleEntry.size());
+		assertEquals(1, lmtSingleEntry.entrySet().size());
 	}
 
 	@Test
 	public void testInitializationMultipleEntries() {
 
 		final LabelMultisetEntryList multipleEntries = new LabelMultisetEntryList();
-		final int numEntries = rnd.nextInt(20);
-		for (int i = 0; i < numEntries; ++i)
-			multipleEntries.add(new LabelMultisetEntry(rnd.nextInt(1000), rnd.nextInt(10)));
+		final Set<Long> uniqueEntries = new HashSet<>();
+		int totalCount = 0;
+		for (int i = 0; i < rnd.nextInt(20); ++i) {
+			final LabelMultisetEntry entry = new LabelMultisetEntry(rnd.nextInt(1000), rnd.nextInt(10));
+			uniqueEntries.add(entry.getId());
+			totalCount += entry.getCount();
+			multipleEntries.add(entry);
+			assertEquals("Sum of all counts", totalCount, multipleEntries.multisetSize());
+			assertEquals("Unique entry IDs", uniqueEntries.size(), multipleEntries.size());
+		}
 		final LabelMultisetType lmtMultipleEntries = new LabelMultisetType(multipleEntries);
-		Assert.assertEquals(numEntries, lmtMultipleEntries.entrySet().size());
+		assertEquals(uniqueEntries.size(), lmtMultipleEntries.entrySet().size());
+		assertEquals(totalCount, lmtMultipleEntries.size());
 		final Iterator<? extends LabelMultisetEntry> itExpected = multipleEntries.iterator();
 		final Iterator<LabelMultisetType.Entry<Label>> itActual = lmtMultipleEntries.entrySet().iterator();
 		while (itExpected.hasNext() || itActual.hasNext()) {
 			final LabelMultisetEntry entryExpected = itExpected.next();
 			final LabelMultisetType.Entry<Label> entryActual = itActual.next();
-			Assert.assertEquals(entryExpected.getElement().id(), entryActual.getElement().id());
-			Assert.assertEquals(entryExpected.getCount(), entryActual.getCount());
+			assertEquals(entryExpected.getElement().id(), entryActual.getElement().id());
+			assertEquals(entryExpected.getCount(), entryActual.getCount());
 		}
 	}
 
@@ -54,8 +293,8 @@ public class LabelMultisetTypeTest {
 		entries.add(new LabelMultisetEntry(3, 15));
 		entries.add(new LabelMultisetEntry(4, 11));
 		entries.add(new LabelMultisetEntry(1, 14));
-		Assert.assertEquals(3, LabelUtils.getArgMax(entries));
+		assertEquals(3, LabelUtils.getArgMax(entries));
 		final LabelMultisetType lmt = new LabelMultisetType(entries);
-		Assert.assertEquals(3, lmt.argMax());
+		assertEquals(3, lmt.argMax());
 	}
 }

--- a/src/test/java/net/imglib2/type/label/SerializationTest.java
+++ b/src/test/java/net/imglib2/type/label/SerializationTest.java
@@ -17,8 +17,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -32,7 +30,7 @@ public class SerializationTest {
 	@Test
 	public void randomSingleEntryImageSerializationTest() {
 
-		final Random rng = new Random();
+		final Random rng = new Random(10);
 		final int dim = 32;
 		final long[] dims = {dim, dim, dim};
 		final RandomAccessibleInterval<LongType> img = ArrayImgs.longs(dims);
@@ -80,7 +78,7 @@ public class SerializationTest {
 		N5Writer n5 = new N5FSWriter(Files.createTempDirectory("n5-test").toString());
 		try {
 			final long[] dims = {10, 20, 30};
-			final Random rand = new Random();
+			final Random rand = new Random(10);
 
 			final int numElements = (int)Intervals.numElements(dims);
 			final List<LabelMultisetType> typeElements = new ArrayList<>();
@@ -136,9 +134,8 @@ public class SerializationTest {
 		N5Writer n5 = new N5FSWriter(Files.createTempDirectory("n5-test").toString());
 		try {
 			final long[] dims = {1};
-			final int[] blockSize = {1};
 
-			final Random rand = new Random();
+			final Random rand = new Random(10);
 
 			final int numElements = (int)Intervals.numElements(dims);
 			final List<LabelMultisetType> typeElements = new ArrayList<>();


### PR DESCRIPTION
Add some more implementations where reasonable defaults could be assumed, or where unambiguous:
### LabelMultisetType:
- `add`
- `addAll`
- `set`
- `clear`
- `setInteger`
- `compareTo`
### LabelMultisetEntryList
- `add`
- `addAll`

### Miscellaneous
#### behavioral changes
- `LabelMultisetType`/`LabelMultisetEntriesList` now are assumed to be ordered by `id` of the entries, unless explicitly changed, in which case it is the responsibility of the developer to change it back prior to intended usage
- Entries in `LabelMultisetType`/`LabelMultisetEntriesList` are merged on construction/add/set, so that only one entry with a given `id` should exist.
- `argMax` behavior when multiple entries contain the same `count` is now defined
  - previously, if multiple entries with the same count, the first encountered would be `argMax`
    - Since it was not gauranteed to be sorted before, this could lead to different argMax for same entries, based on order in the list
  - if multiple entries have the same count, the numerically lowest id will be considered `argMax`
#### Performance
- updated to `serialize` and `downscale` logic
- reduce calls to `sortById` and `updateArgMax`
#### Tests
- add tests for new LabelMultisetType methods
- add test for serializing images whose LabelMultisetTypes contain multiple entries
  - the same [test that is already in `n5-imglib2`](https://github.com/saalfeldlab/n5-imglib2/blob/2da3143597a37014a318e9c01d407fb1e8ac53b2/src/test/java/org/janelia/saalfeldlab/n5/imglib2/N5LabelMultisetsTest.java#L103)