### PR TITLE
fix: incorrect size when initialized with long[] length 0

### DIFF
--- a/src/main/java/net/imglib2/type/label/MappedObjectArrayList.java
+++ b/src/main/java/net/imglib2/type/label/MappedObjectArrayList.java
@@ -57,7 +57,10 @@ public class MappedObjectArrayList<O extends MappedObject<O, T>, T extends Mappe
 	this.baseOffset = baseOffset;
 	this.elementBaseOffset = baseOffset + ByteUtils.INT_SIZE;
 	data.updateAccess(access, baseOffset);
-	size = access.getInt(0);
+	if (baseOffset < data.size())
+		size = access.getInt(0);
+	else
+		size = 0;
   }
 
   public void createListAt(final MappedAccessData<T> data, final long baseOffset) {

--- a/src/test/java/net/imglib2/type/label/LabelMultisetEntryListTest.java
+++ b/src/test/java/net/imglib2/type/label/LabelMultisetEntryListTest.java
@@ -1,0 +1,46 @@
+package net.imglib2.type.label;
+
+import com.google.common.collect.Streams;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+
+public class LabelMultisetEntryListTest {
+
+	@Test
+	public void sizeCheck() {
+
+		LabelMultisetEntryList lmel = new LabelMultisetEntryList();
+		assertEquals(0, lmel.size());
+
+		LongMappedAccessData listData = LongMappedAccessData.factory.createStorage(0);
+		lmel = new LabelMultisetEntryList(listData, 0);
+		assertEquals(0, lmel.size());
+
+		listData = LongMappedAccessData.factory.createStorage(16);
+		lmel = new LabelMultisetEntryList(listData, 0);
+		assertEquals(0, lmel.size());
+
+		listData = LongMappedAccessData.factory.createStorage(16);
+		lmel = new LabelMultisetEntryList(listData, 0);
+		lmel.add(new LabelMultisetEntry(1, 10));
+		assertEquals(1, lmel.size());
+
+		listData = LongMappedAccessData.factory.createStorage(0);
+		lmel = new LabelMultisetEntryList(listData, 0);
+		lmel.add(new LabelMultisetEntry(1, 10));
+		lmel.add(new LabelMultisetEntry(1, 10));
+		lmel.add(new LabelMultisetEntry(2, 10));
+		assertEquals(2, lmel.size());
+	}
+
+}


### PR DESCRIPTION
caused buffer overflow when size would incorrectly return a positive number, and later attempting to sort by id on the empty list, UNSAFE would try to copyMemory outside of the list crashing the application.