### PR TITLE
Fix/serialization hash collision

### DIFF
--- a/src/main/java/net/imglib2/type/label/ComparableLabelMultisetEntryList.java
+++ b/src/main/java/net/imglib2/type/label/ComparableLabelMultisetEntryList.java
@@ -1,0 +1,58 @@
+package net.imglib2.type.label;
+
+class ComparableLabelMultisetEntryList extends LabelMultisetEntryList implements Comparable<LabelMultisetEntryList> {
+
+	private final LabelMultisetEntry ref;
+
+	ComparableLabelMultisetEntryList() {
+		this(new LabelMultisetEntry());
+	}
+
+	ComparableLabelMultisetEntryList(final LabelMultisetEntry ref) {
+
+		this.ref = ref;
+	}
+
+	ComparableLabelMultisetEntryList(final LabelMultisetEntryList list) {
+		this(list, new LabelMultisetEntry());
+
+	}
+	ComparableLabelMultisetEntryList(final LabelMultisetEntryList list, final LabelMultisetEntry ref) {
+
+		this.ref = ref;
+		referToDataAt(list.data, list.getBaseOffset());
+	}
+
+	@Override public LabelMultisetEntry createRef() {
+
+		return ref;
+	}
+
+	@Override public int compareTo(LabelMultisetEntryList o) {
+
+		final int size = size();
+
+		/* if different sizes or empty, return result of compare size*/
+		final int sizeCompare = Integer.compare(size, o.size());
+		if (sizeCompare != 0 || size == 0)
+			return sizeCompare;
+
+		final RefIterator<LabelMultisetEntry> thisIter = iterator();
+		final RefIterator<LabelMultisetEntry> otherIter = o.iterator();
+
+		for (int i = 0; i < size; i++) {
+			final LabelMultisetEntry thisNext = thisIter.next();
+			final LabelMultisetEntry otherNext = otherIter.next();
+
+			final int idCompare = Long.compare(thisNext.getId(), otherNext.getId());
+			if (idCompare != 0)
+				return idCompare;
+
+			final int countCompare = Integer.compare(thisNext.getCount(), otherNext.getCount());
+			if (countCompare != 0)
+				return countCompare;
+		}
+
+		return 0;
+	}
+}

--- a/src/main/java/net/imglib2/type/label/LabelMultisetEntryList.java
+++ b/src/main/java/net/imglib2/type/label/LabelMultisetEntryList.java
@@ -3,7 +3,6 @@ package net.imglib2.type.label;
 import net.imglib2.type.label.LabelMultisetType.Entry;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
@@ -13,7 +12,7 @@ import java.util.Set;
  * all add operations should insert appropriately to remain sorted. If `sortByCount` is ever called (or the order is manually changed)
  * it is the developers responsibility to `sortById()` prior to any additional calls.
  */
-public class LabelMultisetEntryList extends MappedObjectArrayList<LabelMultisetEntry, LongMappedAccess> implements Comparable<LabelMultisetEntryList> {
+public class LabelMultisetEntryList extends MappedObjectArrayList<LabelMultisetEntry, LongMappedAccess> {
 
 	public LabelMultisetEntryList() {
 
@@ -43,7 +42,9 @@ public class LabelMultisetEntryList extends MappedObjectArrayList<LabelMultisetE
 		if (!(o instanceof LabelMultisetEntryList)) return false;
 		final LabelMultisetEntryList other = (LabelMultisetEntryList)o;
 		if (other.size() != size()) return false;
-		return compareTo(other) == 0;
+		final ComparableLabelMultisetEntryList thisComparable = new ComparableLabelMultisetEntryList(this);
+		final ComparableLabelMultisetEntryList otherComparable = new ComparableLabelMultisetEntryList(other);
+		return thisComparable.compareTo(otherComparable) == 0;
 	}
 
 	public LabelMultisetEntryList(final int capacity) {
@@ -393,29 +394,5 @@ public class LabelMultisetEntryList extends MappedObjectArrayList<LabelMultisetE
 			}
 		}
 		releaseRef(e1);
-	}
-
-	@Override public int compareTo(LabelMultisetEntryList o) {
-
-		final int size = size();
-
-		final int sizeCompare = Integer.compare(size, o.size());
-		if (sizeCompare != 0) return sizeCompare;
-
-		final RefIterator<LabelMultisetEntry> thisIter = iterator();
-		final RefIterator<LabelMultisetEntry> otherIter = o.iterator();
-
-		for (int i = 0; i < size; i++) {
-			final LabelMultisetEntry thisNext = thisIter.next();
-			final LabelMultisetEntry otherNext = otherIter.next();
-
-			final int idCompare = Long.compare(thisNext.getId(), otherNext.getId());
-			if (idCompare != 0) return idCompare;
-
-			final int countCompare = Long.compare(thisNext.getCount(), otherNext.getCount());
-			if (countCompare != 0) return countCompare;
-		}
-
-		return 0;
 	}
 }

--- a/src/main/java/net/imglib2/type/label/LabelMultisetEntryList.java
+++ b/src/main/java/net/imglib2/type/label/LabelMultisetEntryList.java
@@ -43,7 +43,6 @@ public class LabelMultisetEntryList extends MappedObjectArrayList<LabelMultisetE
 		if (!(o instanceof LabelMultisetEntryList)) return false;
 		final LabelMultisetEntryList other = (LabelMultisetEntryList)o;
 		if (other.size() != size()) return false;
-		if (other.hashCode() != hashCode()) return false;
 		return compareTo(other) == 0;
 	}
 

--- a/src/main/java/net/imglib2/type/label/LabelMultisetEntryList.java
+++ b/src/main/java/net/imglib2/type/label/LabelMultisetEntryList.java
@@ -13,7 +13,7 @@ import java.util.Set;
  * all add operations should insert appropriately to remain sorted. If `sortByCount` is ever called (or the order is manually changed)
  * it is the developers responsibility to `sortById()` prior to any additional calls.
  */
-public class LabelMultisetEntryList extends MappedObjectArrayList<LabelMultisetEntry, LongMappedAccess> {
+public class LabelMultisetEntryList extends MappedObjectArrayList<LabelMultisetEntry, LongMappedAccess> implements Comparable<LabelMultisetEntryList> {
 
 	public LabelMultisetEntryList() {
 
@@ -43,9 +43,8 @@ public class LabelMultisetEntryList extends MappedObjectArrayList<LabelMultisetE
 		if (!(o instanceof LabelMultisetEntryList)) return false;
 		final LabelMultisetEntryList other = (LabelMultisetEntryList)o;
 		if (other.size() != size()) return false;
-		final long[] thisData = ((LongMappedAccessData) data).getData();
-		final long[] otherData = ((LongMappedAccessData) other.data).getData();
-		return Arrays.equals(thisData, otherData);
+		if (other.hashCode() != hashCode()) return false;
+		return compareTo(other) == 0;
 	}
 
 	public LabelMultisetEntryList(final int capacity) {
@@ -395,5 +394,29 @@ public class LabelMultisetEntryList extends MappedObjectArrayList<LabelMultisetE
 			}
 		}
 		releaseRef(e1);
+	}
+
+	@Override public int compareTo(LabelMultisetEntryList o) {
+
+		final int size = size();
+
+		final int sizeCompare = Integer.compare(size, o.size());
+		if (sizeCompare != 0) return sizeCompare;
+
+		final RefIterator<LabelMultisetEntry> thisIter = iterator();
+		final RefIterator<LabelMultisetEntry> otherIter = o.iterator();
+
+		for (int i = 0; i < size; i++) {
+			final LabelMultisetEntry thisNext = thisIter.next();
+			final LabelMultisetEntry otherNext = otherIter.next();
+
+			final int idCompare = Long.compare(thisNext.getId(), otherNext.getId());
+			if (idCompare != 0) return idCompare;
+
+			final int countCompare = Long.compare(thisNext.getCount(), otherNext.getCount());
+			if (countCompare != 0) return countCompare;
+		}
+
+		return 0;
 	}
 }

--- a/src/main/java/net/imglib2/type/label/LabelMultisetType.java
+++ b/src/main/java/net/imglib2/type/label/LabelMultisetType.java
@@ -287,8 +287,7 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 					access.isValid(),
 					access.argMaxCopy());
 			/* get a new type instance */
-			final LabelMultisetType that = new LabelMultisetType(null, accessCopy);
-			return that;
+			return new LabelMultisetType(null, accessCopy);
 		}
 	}
 
@@ -709,7 +708,9 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 		final int countCompare = Long.compare(count(ours), count(theirs));
 		if (countCompare != 0) return countCompare;
 
-		return labelMultisetEntries().compareTo(arg0.labelMultisetEntries());
+		final ComparableLabelMultisetEntryList thisComparable = new ComparableLabelMultisetEntryList(labelMultisetEntries());
+		final ComparableLabelMultisetEntryList otherComparable = new ComparableLabelMultisetEntryList(arg0.labelMultisetEntries());
+		return thisComparable.compareTo(otherComparable);
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/label/LabelMultisetType.java
+++ b/src/main/java/net/imglib2/type/label/LabelMultisetType.java
@@ -702,10 +702,14 @@ public class LabelMultisetType extends AbstractNativeType<LabelMultisetType> imp
 
 		final long ours = argMax();
 		final long theirs = arg0.argMax();
-		final int initialComparison = Long.compare(ours, theirs);
 
-		if (initialComparison != 0) return initialComparison;
-		else return Long.compare(count(ours), count(theirs));
+		final int argMaxCompare = Long.compare(ours, theirs);
+		if (argMaxCompare != 0) return argMaxCompare;
+
+		final int countCompare = Long.compare(count(ours), count(theirs));
+		if (countCompare != 0) return countCompare;
+
+		return labelMultisetEntries().compareTo(arg0.labelMultisetEntries());
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/label/VolatileLabelMultisetArray.java
+++ b/src/main/java/net/imglib2/type/label/VolatileLabelMultisetArray.java
@@ -112,6 +112,8 @@ public class VolatileLabelMultisetArray implements VolatileAccess, VolatileArray
 
   public long argMax(final int offset) {
 
+  	if (data.length == 0)
+	  return Label.INVALID;
 	return this.argMax[offset];
   }
 


### PR DESCRIPTION
There were some issues with occasional hash collisions when serializing LabelMultisetType images. This aims to solve in the following ways:

- implement comparable so LabelMultisetEntryList is comparable by the following rules:
  - lists with fewer entries are less than lists with more entries
  - lists with the same number entries compare for each entry on their ID
    - if the IDs at an entry are the same, compare against the counts for that ID 

This lets us use a TreeMap in the serialization logic, instead of a HashMap. The comparator is sorted first by size to ensure smaller lists are checked for equality first.